### PR TITLE
Use the DiaSource interface instead of class.

### DIFF
--- a/SymbolSort.cs
+++ b/SymbolSort.cs
@@ -1155,7 +1155,7 @@ namespace SymbolSort
 
         private static void ReadSymbolsFromPDB(List<Symbol> symbols, string filename, string searchPath, Options options)
         {
-            DiaSourceClass diaSource = new DiaSourceClass();
+            DiaSource diaSource = new DiaSource();
 
             if (Path.GetExtension(filename).ToLower() == ".pdb")
             {

--- a/SymbolSort.txt
+++ b/SymbolSort.txt
@@ -210,14 +210,6 @@ fixed by running this command from an administrator command prompt:
 
     regsvr32 "c:\Program Files (x86)\Microsoft Visual Studio 14.0\DIA SDK\bin\amd64\msdia140.dll"
 
-If you are targeting .NET Framework version >= 4.0, you may receive the following error
-on attempting to build: 
-
-    Interop type 'DiaSourceClass' cannot be embedded. Use the applicable interface instead.
-    
-To fix this either target an earlier .NET Framework or change the "Embed Interop Types"
-property on the Dia2Lib reference to False.
-
 
 REVISION HISTORY:
 


### PR DESCRIPTION
This fixes interop embed error when targeting .NET Framework version >= 4.0.