### PR TITLE
Trim null chars at the end of section name.

### DIFF
--- a/SymbolSort.cs
+++ b/SymbolSort.cs
@@ -128,7 +128,7 @@ namespace Dia2Lib
     {
         [FieldOffset(0)]
         [MarshalAs(UnmanagedType.ByValArray, SizeConst = 8)]
-        public char[] ShortName;
+        public byte[] ShortName;
         [FieldOffset(8)]
         public UInt32 VirtualSize;
         [FieldOffset(12)]
@@ -148,7 +148,7 @@ namespace Dia2Lib
         [FieldOffset(36)]
         public DataSectionFlags Characteristics;
 
-        public string Name { get { return new string(ShortName); } }
+        public string Name => Encoding.UTF8.GetString(ShortName).TrimEnd('\0');
     }
 
     // This class is a specialization of IDiaEnumDebugStreamData.


### PR DESCRIPTION
Ensure that proper encoding is used.