### PR TITLE
Added x64 configuration.

### DIFF
--- a/SymbolSort.csproj
+++ b/SymbolSort.csproj
@@ -32,6 +32,26 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x64\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <OutputPath>bin\x64\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/SymbolSort.sln
+++ b/SymbolSort.sln
@@ -8,13 +8,19 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{8F244FB4-27B7-4E56-A116-1B871B35DF31}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{8F244FB4-27B7-4E56-A116-1B871B35DF31}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8F244FB4-27B7-4E56-A116-1B871B35DF31}.Debug|x64.ActiveCfg = Debug|x64
+		{8F244FB4-27B7-4E56-A116-1B871B35DF31}.Debug|x64.Build.0 = Debug|x64
 		{8F244FB4-27B7-4E56-A116-1B871B35DF31}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8F244FB4-27B7-4E56-A116-1B871B35DF31}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8F244FB4-27B7-4E56-A116-1B871B35DF31}.Release|x64.ActiveCfg = Release|x64
+		{8F244FB4-27B7-4E56-A116-1B871B35DF31}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Currently only "Any CPU" config is present, which starts as 32-bit process. When it hits 1.5 GB memory usage, it simply crashes. In x64 config, everything works fine.
I believe it was also mentioned in https://github.com/adrianstone55/SymbolSort/issues/8.
