### PR TITLE
Do not allow symbols from different sources affect each other

### DIFF
--- a/SymbolSort.cs
+++ b/SymbolSort.cs
@@ -1140,9 +1140,10 @@ namespace SymbolSort
         }
 
 
-        private static void ReadSymbolsFromPDB(List<Symbol> symbols, string filename, string searchPath, Options options)
+        private static void ReadSymbolsFromPDB(List<Symbol> symbolsOutput, string filename, string searchPath, Options options)
         {
             DiaSource diaSource = new DiaSource();
+            List<Symbol> symbols = new List<Symbol>();
 
             if (Path.GetExtension(filename).ToLower() == ".pdb")
             {
@@ -1221,6 +1222,9 @@ namespace SymbolSort
                 Console.WriteLine("{0,3}", 100);
                 symbols.RemoveAll(delegate(Symbol s) { return s.size == 0 && ((s.flags & SymbolFlags.Weak) == SymbolFlags.Weak); });
             }
+
+            //add read symbols to the output list
+            symbolsOutput.AddRange(symbols);
         }
 
         private static void WriteSymbolList(TextWriter writer, List<Symbol> symbolList, int maxCount)


### PR DESCRIPTION
Process each PDB separately from other inputs.
Do not allow symbols from different PDB files overlap each other by RVA.