### PR TITLE
Backported to MSVC2013

### DIFF
--- a/App.config
+++ b/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/>
     </startup>
 </configuration>

--- a/SymbolSort.cs
+++ b/SymbolSort.cs
@@ -131,7 +131,12 @@ namespace Dia2Lib
         [FieldOffset(36)]
         public DataSectionFlags Characteristics;
 
-        public string Name => Encoding.UTF8.GetString(ShortName).TrimEnd('\0');
+        public string Name {
+            get
+            {
+                return Encoding.UTF8.GetString(ShortName).TrimEnd('\0');
+            }
+        }
     }
 
     // This class is a specialization of IDiaEnumDebugStreamData.

--- a/SymbolSort.csproj
+++ b/SymbolSort.csproj
@@ -9,9 +9,10 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SymbolSort</RootNamespace>
     <AssemblyName>SymbolSort</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>


### PR DESCRIPTION
Trivial changes to make SymbolSort work on C# from MSVC 2013.