### PR TITLE
Options refactor

### DIFF
--- a/SymbolSort.cs
+++ b/SymbolSort.cs
@@ -197,7 +197,7 @@ namespace SymbolSort
     };
 
     [Flags]
-    enum Options
+    enum UserFlags
     {
         None = 0x0,
         DumpCompleteSymbols = 0x1,
@@ -1171,7 +1171,7 @@ namespace SymbolSort
         }
 
 
-        private static void ReadSymbolsFromPDB(List<Symbol> symbolsOutput, string filename, string searchPath, Options options)
+        private static void ReadSymbolsFromPDB(List<Symbol> symbolsOutput, string filename, string searchPath, UserFlags options)
         {
             DiaSource diaSource = new DiaSource();
             List<Symbol> symbols = new List<Symbol>();
@@ -1203,7 +1203,7 @@ namespace SymbolSort
             // Symbols are loaded in priority order.  Symbols loaded earlier will be preferred to
             // symbols loaded later when removing overlapping and redundant symbols.
 
-            bool includePublicSymbols = (options & Options.IncludePublicSymbols) == Options.IncludePublicSymbols;
+            bool includePublicSymbols = (options & UserFlags.IncludePublicSymbols) == UserFlags.IncludePublicSymbols;
             if (includePublicSymbols)
             {
                 // Generic public symbols are preferred to global function and data symbols because they will included alignment in
@@ -1233,7 +1233,7 @@ namespace SymbolSort
             ReadSymbolsFromScope(globalScope, SymTagEnum.SymTagData, SymbolFlags.Weak, 0, 100, diaSession, sectionContribs, compilandFileMap, symbols);
             Console.WriteLine();
 
-            bool includeSectionsAsSymbols = (options & Options.IncludeSectionsAsSymbols) == Options.IncludeSectionsAsSymbols;
+            bool includeSectionsAsSymbols = (options & UserFlags.IncludeSectionsAsSymbols) == UserFlags.IncludeSectionsAsSymbols;
             if (includeSectionsAsSymbols)
             {
                 Console.Write("Reading sections as symbols... ");
@@ -1241,7 +1241,7 @@ namespace SymbolSort
                 Console.WriteLine("{0,3}", 100);
             }
 
-            bool keepRedundantSymbols = (options & Options.KeepRedundantSymbols) == Options.KeepRedundantSymbols;
+            bool keepRedundantSymbols = (options & UserFlags.KeepRedundantSymbols) == UserFlags.KeepRedundantSymbols;
             if (keepRedundantSymbols)
             {
                 AddSymbolsForMissingAddresses(symbols);
@@ -1536,7 +1536,7 @@ namespace SymbolSort
             writer.WriteLine();
         }
 
-        private static void LoadSymbols(InputFile inputFile, List<Symbol> symbols, string searchPath, Options options)
+        private static void LoadSymbols(InputFile inputFile, List<Symbol> symbols, string searchPath, UserFlags options)
         {
             Console.WriteLine("Loading symbols from {0}", inputFile.filename);
             switch (inputFile.type)
@@ -1563,7 +1563,7 @@ namespace SymbolSort
             out int maxCount, 
             out List<string> exclusions,
             out List<RegexReplace> pathReplacements,
-            out Options options)
+            out UserFlags options)
         {
             maxCount = 500;
             exclusions = new List<string>();
@@ -1656,23 +1656,23 @@ namespace SymbolSort
                     }
                     else if (curArgStr == "-complete")
                     {
-                        options |= Options.DumpCompleteSymbols;
+                        options |= UserFlags.DumpCompleteSymbols;
                     }
                     else if (curArgStr == "-include_public_symbols")
                     {
-                        options |= Options.IncludePublicSymbols;
+                        options |= UserFlags.IncludePublicSymbols;
                     }
                     else if (curArgStr == "-keep_redundant_symbols")
                     {
-                        options |= Options.KeepRedundantSymbols;
+                        options |= UserFlags.KeepRedundantSymbols;
                     }
                     else if (curArgStr == "-include_sections_as_symbols")
                     {
-                        options |= Options.IncludeSectionsAsSymbols;
+                        options |= UserFlags.IncludeSectionsAsSymbols;
                     }
                     else if (curArgStr == "-include_unmapped_addresses")
                     {
-                        options |= Options.IncludeUnmappedAddresses;
+                        options |= UserFlags.IncludeUnmappedAddresses;
                     }
                     else if (curArgStr == "-options_from_file")
                     {
@@ -1711,7 +1711,7 @@ namespace SymbolSort
             List<RegexReplace> pathReplacements;
             string outFilename;
             string searchPath;
-            Options options;
+            UserFlags options;
             if (!ParseArgs(args, out inputFiles, out outFilename, out differenceFiles, out searchPath, out maxCount, out exclusions, out pathReplacements, out options))
             {
                 Console.WriteLine();
@@ -1864,7 +1864,7 @@ namespace SymbolSort
                 }
 
                 if (unknownSize > 0 &&
-                    (options & Options.IncludeUnmappedAddresses) != Options.IncludeUnmappedAddresses)
+                    (options & UserFlags.IncludeUnmappedAddresses) != UserFlags.IncludeUnmappedAddresses)
                 {
                     symbols.RemoveAll(delegate(Symbol s) { return (s.flags & SymbolFlags.Unmapped) == SymbolFlags.Unmapped; });
                 }
@@ -1973,7 +1973,7 @@ namespace SymbolSort
                 maxCount,
                 differenceFiles.Any());
 
-            if ((options & Options.DumpCompleteSymbols) == Options.DumpCompleteSymbols)
+            if ((options & UserFlags.DumpCompleteSymbols) == UserFlags.DumpCompleteSymbols)
             {
                 Console.WriteLine("Dumping all symbols...");
                 symbols.Sort(

--- a/SymbolSort.cs
+++ b/SymbolSort.cs
@@ -1563,7 +1563,7 @@ namespace SymbolSort
             public int maxCount;
             public List<string> exclusions;
             public List<RegexReplace> pathReplacements;
-            public UserFlags options;
+            public UserFlags flags;
         }
 
         private static UserOptions ParseArgs(string[] args)
@@ -1576,7 +1576,7 @@ namespace SymbolSort
             opts.differenceFiles = new List<InputFile>();
             opts.searchPath = null;
             opts.pathReplacements = new List<RegexReplace>();
-            opts.options = 0;
+            opts.flags = 0;
 
             if (args.Length < 1)
                 return null;
@@ -1660,23 +1660,23 @@ namespace SymbolSort
                     }
                     else if (curArgStr == "-complete")
                     {
-                        opts.options |= UserFlags.DumpCompleteSymbols;
+                        opts.flags |= UserFlags.DumpCompleteSymbols;
                     }
                     else if (curArgStr == "-include_public_symbols")
                     {
-                        opts.options |= UserFlags.IncludePublicSymbols;
+                        opts.flags |= UserFlags.IncludePublicSymbols;
                     }
                     else if (curArgStr == "-keep_redundant_symbols")
                     {
-                        opts.options |= UserFlags.KeepRedundantSymbols;
+                        opts.flags |= UserFlags.KeepRedundantSymbols;
                     }
                     else if (curArgStr == "-include_sections_as_symbols")
                     {
-                        opts.options |= UserFlags.IncludeSectionsAsSymbols;
+                        opts.flags |= UserFlags.IncludeSectionsAsSymbols;
                     }
                     else if (curArgStr == "-include_unmapped_addresses")
                     {
-                        opts.options |= UserFlags.IncludeUnmappedAddresses;
+                        opts.flags |= UserFlags.IncludeUnmappedAddresses;
                     }
                     else if (curArgStr == "-options_from_file")
                     {
@@ -1815,14 +1815,14 @@ namespace SymbolSort
             List<Symbol> symbols = new List<Symbol>();
             foreach (InputFile inputFile in opts.inputFiles)
             {
-                LoadSymbols(inputFile, symbols, opts.searchPath, opts.options);
+                LoadSymbols(inputFile, symbols, opts.searchPath, opts.flags);
                 Console.WriteLine();
             }
 
             foreach (InputFile inputFile in opts.differenceFiles)
             {
                 List<Symbol> negativeSymbols = new List<Symbol>();
-                LoadSymbols(inputFile, negativeSymbols, opts.searchPath, opts.options);
+                LoadSymbols(inputFile, negativeSymbols, opts.searchPath, opts.flags);
                 Console.WriteLine();
                 foreach (Symbol s in negativeSymbols)
                 {
@@ -1861,7 +1861,7 @@ namespace SymbolSort
                 }
 
                 if (unknownSize > 0 &&
-                    (opts.options & UserFlags.IncludeUnmappedAddresses) != UserFlags.IncludeUnmappedAddresses)
+                    (opts.flags & UserFlags.IncludeUnmappedAddresses) != UserFlags.IncludeUnmappedAddresses)
                 {
                     symbols.RemoveAll(delegate(Symbol s) { return (s.flags & SymbolFlags.Unmapped) == SymbolFlags.Unmapped; });
                 }
@@ -1970,7 +1970,7 @@ namespace SymbolSort
                 opts.maxCount,
                 opts.differenceFiles.Any());
 
-            if ((opts.options & UserFlags.DumpCompleteSymbols) == UserFlags.DumpCompleteSymbols)
+            if ((opts.flags & UserFlags.DumpCompleteSymbols) == UserFlags.DumpCompleteSymbols)
             {
                 Console.WriteLine("Dumping all symbols...");
                 symbols.Sort(

--- a/SymbolSort.cs
+++ b/SymbolSort.cs
@@ -1556,27 +1556,19 @@ namespace SymbolSort
 
         class UserOptions
         {
-            public List<InputFile> inputFiles;
-            public string outFilename;
-            public List<InputFile> differenceFiles;
-            public string searchPath;
-            public int maxCount;
-            public List<string> exclusions;
-            public List<RegexReplace> pathReplacements;
-            public UserFlags flags;
+            public List<InputFile> inputFiles = new List<InputFile>();
+            public string outFilename = null;
+            public List<InputFile> differenceFiles = new List<InputFile>();
+            public string searchPath = null;
+            public int maxCount = 500;
+            public List<string> exclusions = new List<string>();
+            public List<RegexReplace> pathReplacements = new List<RegexReplace>();
+            public UserFlags flags = 0;
         }
 
         private static UserOptions ParseArgs(string[] args)
         {
             UserOptions opts = new UserOptions();
-            opts.maxCount = 500;
-            opts.exclusions = new List<string>();
-            opts.inputFiles = new List<InputFile>();
-            opts.outFilename = null;
-            opts.differenceFiles = new List<InputFile>();
-            opts.searchPath = null;
-            opts.pathReplacements = new List<RegexReplace>();
-            opts.flags = 0;
 
             if (args.Length < 1)
                 return null;


### PR DESCRIPTION
With the previous state of code it was very hard to add or remove command line parameters independently, because they were listed in four places (on single line in one place). This caused stupid merge conflicts.

Now the list of all settings is written in one place, so it is easier to experiment with cmd arguments.